### PR TITLE
feat (trainer): create trainer profile end to end

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,29 +6,36 @@
   background: #101820;
   color: #f5f5f5;
   font-family: Arial, sans-serif;
+  padding: 32px;
 }
 
 .card {
   width: 100%;
-  max-width: 420px;
+  max-width: 900px;
   padding: 32px;
   border-radius: 16px;
   background: #1f2933;
 }
 
-h1 {
-  margin-bottom: 8px;
+h1,
+p {
+  text-align: center;
 }
 
-p {
-  color: #cbd5e1;
+.forms {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-top: 24px;
 }
 
 form {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin-top: 24px;
+  padding: 24px;
+  border-radius: 12px;
+  background: #263442;
 }
 
 label {
@@ -56,6 +63,11 @@ button {
 }
 
 .message {
-  margin-top: 16px;
   font-weight: bold;
+}
+
+@media (max-width: 800px) {
+  .forms {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,34 +2,39 @@ import { useState } from "react";
 import "./App.css";
 
 function App() {
-  const [form, setForm] = useState({
+  const [userForm, setUserForm] = useState({
     name: "",
     email: "",
     mode: "SELF_MANAGED",
   });
 
-  const [message, setMessage] = useState("");
+  const [trainerForm, setTrainerForm] = useState({
+    name: "",
+    email: "",
+  });
 
-  function handleChange(event) {
+  const [userMessage, setUserMessage] = useState("");
+  const [trainerMessage, setTrainerMessage] = useState("");
+
+  function handleUserChange(event) {
     const { name, value } = event.target;
-
-    setForm({
-      ...form,
-      [name]: value,
-    });
+    setUserForm({ ...userForm, [name]: value });
   }
 
-  async function handleSubmit(event) {
+  function handleTrainerChange(event) {
+    const { name, value } = event.target;
+    setTrainerForm({ ...trainerForm, [name]: value });
+  }
+
+  async function handleUserSubmit(event) {
     event.preventDefault();
-    setMessage("Creating user...");
+    setUserMessage("Creating user...");
 
     try {
       const response = await fetch("http://localhost:8080/api/users", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(form),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(userForm),
       });
 
       if (!response.ok) {
@@ -37,15 +42,33 @@ function App() {
       }
 
       const createdUser = await response.json();
-
-      setMessage(`User created: ${createdUser.name} (${createdUser.mode})`);
-      setForm({
-        name: "",
-        email: "",
-        mode: "SELF_MANAGED",
-      });
+      setUserMessage(`User created: ${createdUser.name} (${createdUser.mode})`);
+      setUserForm({ name: "", email: "", mode: "SELF_MANAGED" });
     } catch (error) {
-      setMessage("Error creating user. Check backend or CORS.");
+      setUserMessage("Error creating user. Check backend or CORS.");
+    }
+  }
+
+  async function handleTrainerSubmit(event) {
+    event.preventDefault();
+    setTrainerMessage("Creating trainer...");
+
+    try {
+      const response = await fetch("http://localhost:8080/api/trainers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(trainerForm),
+      });
+
+      if (!response.ok) {
+        throw new Error("Could not create trainer");
+      }
+
+      const createdTrainer = await response.json();
+      setTrainerMessage(`Trainer created: ${createdTrainer.name}`);
+      setTrainerForm({ name: "", email: "" });
+    } catch (error) {
+      setTrainerMessage("Error creating trainer. Check backend or CORS.");
     }
   }
 
@@ -53,44 +76,83 @@ function App() {
     <main className="page">
       <section className="card">
         <h1>El arte de la hipertrofia muscular</h1>
-        <p>Create your user profile</p>
+        <p>Create profiles</p>
 
-        <form onSubmit={handleSubmit}>
-          <label>
-            Name
-            <input
-              name="name"
-              value={form.name}
-              onChange={handleChange}
-              placeholder="Ana"
-              required
-            />
-          </label>
+        <div className="forms">
+          <form onSubmit={handleUserSubmit}>
+            <h2>Create user</h2>
 
-          <label>
-            Email
-            <input
-              name="email"
-              type="email"
-              value={form.email}
-              onChange={handleChange}
-              placeholder="ana@test.com"
-              required
-            />
-          </label>
+            <label>
+              Name
+              <input
+                name="name"
+                value={userForm.name}
+                onChange={handleUserChange}
+                placeholder="Ana"
+                required
+              />
+            </label>
 
-          <label>
-            Mode
-            <select name="mode" value={form.mode} onChange={handleChange}>
-              <option value="SELF_MANAGED">Self-managed</option>
-              <option value="SUPERVISED">Supervised</option>
-            </select>
-          </label>
+            <label>
+              Email
+              <input
+                name="email"
+                type="email"
+                value={userForm.email}
+                onChange={handleUserChange}
+                placeholder="ana@test.com"
+                required
+              />
+            </label>
 
-          <button type="submit">Create user</button>
-        </form>
+            <label>
+              Mode
+              <select
+                name="mode"
+                value={userForm.mode}
+                onChange={handleUserChange}
+              >
+                <option value="SELF_MANAGED">Self-managed</option>
+                <option value="SUPERVISED">Supervised</option>
+              </select>
+            </label>
 
-        {message && <p className="message">{message}</p>}
+            <button type="submit">Create user</button>
+
+            {userMessage && <p className="message">{userMessage}</p>}
+          </form>
+
+          <form onSubmit={handleTrainerSubmit}>
+            <h2>Create trainer</h2>
+
+            <label>
+              Name
+              <input
+                name="name"
+                value={trainerForm.name}
+                onChange={handleTrainerChange}
+                placeholder="Coach Laura"
+                required
+              />
+            </label>
+
+            <label>
+              Email
+              <input
+                name="email"
+                type="email"
+                value={trainerForm.email}
+                onChange={handleTrainerChange}
+                placeholder="coach@test.com"
+                required
+              />
+            </label>
+
+            <button type="submit">Create trainer</button>
+
+            {trainerMessage && <p className="message">{trainerMessage}</p>}
+          </form>
+        </div>
       </section>
     </main>
   );

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerCommand.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerCommand.java
@@ -1,0 +1,7 @@
+package com.anaruth.hypertrophyartapp.application.trainer.port.in;
+
+public record CreateTrainerCommand(
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerResult.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerResult.java
@@ -1,0 +1,10 @@
+package com.anaruth.hypertrophyartapp.application.trainer.port.in;
+
+import java.util.UUID;
+
+public record CreateTrainerResult(
+        UUID id,
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerUseCase.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/in/CreateTrainerUseCase.java
@@ -1,0 +1,6 @@
+package com.anaruth.hypertrophyartapp.application.trainer.port.in;
+
+public interface CreateTrainerUseCase {
+
+    CreateTrainerResult createTrainer(CreateTrainerCommand command);
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/out/TrainerRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/out/TrainerRepository.java
@@ -1,0 +1,8 @@
+package com.anaruth.hypertrophyartapp.application.trainer.port.out;
+
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+
+public interface TrainerRepository {
+
+    Trainer save(Trainer trainer);
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/service/CreateTrainerService.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/service/CreateTrainerService.java
@@ -1,0 +1,31 @@
+package com.anaruth.hypertrophyartapp.application.trainer.service;
+
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerCommand;
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerResult;
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerUseCase;
+import com.anaruth.hypertrophyartapp.application.trainer.port.out.TrainerRepository;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateTrainerService implements CreateTrainerUseCase {
+
+    private final TrainerRepository trainerRepository;
+
+    public CreateTrainerService(TrainerRepository trainerRepository) {
+        this.trainerRepository = trainerRepository;
+    }
+
+    @Override
+    public CreateTrainerResult createTrainer(CreateTrainerCommand command) {
+        Trainer trainer = Trainer.create(command.name(), command.email());
+
+        Trainer savedTrainer = trainerRepository.save(trainer);
+
+        return new CreateTrainerResult(
+                savedTrainer.id().value(),
+                savedTrainer.name(),
+                savedTrainer.email()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/Trainer.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/Trainer.java
@@ -1,0 +1,46 @@
+package com.anaruth.hypertrophyartapp.domain.trainer.model;
+
+import java.util.Objects;
+
+public class Trainer {
+
+    private final TrainerId id;
+    private final String name;
+    private final String email;
+
+    private Trainer(TrainerId id, String name, String email) {
+        this.id = Objects.requireNonNull(id);
+        this.name = validateName(name);
+        this.email = validateEmail(email);
+    }
+
+    public static Trainer create(String name, String email) {
+        return new Trainer(TrainerId.newId(), name, email);
+    }
+
+    public TrainerId id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String email() {
+        return email;
+    }
+
+    private String validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Trainer name cannot be blank");
+        }
+        return name.trim();
+    }
+
+    private String validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Trainer email cannot be blank");
+        }
+        return email.trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
@@ -1,0 +1,21 @@
+package com.anaruth.hypertrophyartapp.domain.trainer.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public final class TrainerId {
+
+    private final UUID value;
+
+    private TrainerId(UUID value) {
+        this.value = Objects.requireNonNull(value);
+    }
+
+    public static TrainerId newId() {
+        return new TrainerId(UUID.randomUUID());
+    }
+
+    public UUID value() {
+        return value;
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/CreateTrainerRequest.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/CreateTrainerRequest.java
@@ -1,0 +1,10 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.trainer;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateTrainerRequest(
+        @NotBlank String name,
+        @Email @NotBlank String email
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/TrainerController.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/TrainerController.java
@@ -1,0 +1,37 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.trainer;
+
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerCommand;
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerResult;
+import com.anaruth.hypertrophyartapp.application.trainer.port.in.CreateTrainerUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/trainers")
+@Tag(name = "Trainers", description = "Trainer profile management")
+public class TrainerController {
+
+    private final CreateTrainerUseCase createTrainerUseCase;
+
+    public TrainerController(CreateTrainerUseCase createTrainerUseCase) {
+        this.createTrainerUseCase = createTrainerUseCase;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create trainer profile")
+    public TrainerResponse createTrainer(@Valid @RequestBody CreateTrainerRequest request) {
+        CreateTrainerResult result = createTrainerUseCase.createTrainer(
+                new CreateTrainerCommand(request.name(), request.email())
+        );
+
+        return new TrainerResponse(
+                result.id(),
+                result.name(),
+                result.email()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/TrainerResponse.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/trainer/TrainerResponse.java
@@ -1,0 +1,10 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.trainer;
+
+import java.util.UUID;
+
+public record TrainerResponse(
+        UUID id,
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryTrainerRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryTrainerRepository.java
@@ -1,0 +1,21 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.memory;
+
+import com.anaruth.hypertrophyartapp.application.trainer.port.out.TrainerRepository;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryTrainerRepository implements TrainerRepository {
+
+    private final Map<UUID, Trainer> trainers = new ConcurrentHashMap<>();
+
+    @Override
+    public Trainer save(Trainer trainer) {
+        trainers.put(trainer.id().value(), trainer);
+        return trainer;
+    }
+}


### PR DESCRIPTION
## Summary

End-to-end implementation of trainer profile creation.

## Changes

- Added Trainer domain model
- Added create trainer use case
- Added in-memory trainer repository
- Added POST /api/trainers endpoint
- Added trainer form in React frontend
- Connected frontend with backend

## Checks

- [x] Maven compile
- [x] Backend starts
- [x] Swagger tested
- [x] Frontend tested manually