### PR TITLE
feat(user): assign trainer to supervised en to end

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,12 @@ function App() {
 
   const [userMessage, setUserMessage] = useState("");
   const [trainerMessage, setTrainerMessage] = useState("");
+  const [assignmentForm, setAssignmentForm] = useState({
+    userId: "",
+    trainerId: "",
+  });
+
+  const [assignmentMessage, setAssignmentMessage] = useState("");
 
   function handleUserChange(event) {
     const { name, value } = event.target;
@@ -26,6 +32,10 @@ function App() {
     setTrainerForm({ ...trainerForm, [name]: value });
   }
 
+  function handleAssignmentChange(event) {
+    const { name, value } = event.target;
+    setAssignmentForm({ ...assignmentForm, [name]: value });
+  }
   async function handleUserSubmit(event) {
     event.preventDefault();
     setUserMessage("Creating user...");
@@ -71,6 +81,39 @@ function App() {
       setTrainerMessage("Error creating trainer. Check backend or CORS.");
     }
   }
+
+    async function handleAssignmentSubmit(event) {
+      event.preventDefault();
+      setAssignmentMessage("Assigning trainer...");
+
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/users/${assignmentForm.userId}/assign-trainer/${assignmentForm.trainerId}`,
+          {
+            method: "POST",
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Could not assign trainer");
+        }
+
+        const assignment = await response.json();
+
+        setAssignmentMessage(
+          `Trainer assigned to user: ${assignment.userName}`
+        );
+
+        setAssignmentForm({
+          userId: "",
+          trainerId: "",
+        });
+      } catch (error) {
+        setAssignmentMessage(
+          "Error assigning trainer. Check IDs or user mode."
+        );
+      }
+    }
 
   return (
     <main className="page">
@@ -151,6 +194,36 @@ function App() {
             <button type="submit">Create trainer</button>
 
             {trainerMessage && <p className="message">{trainerMessage}</p>}
+          </form>
+
+          <form onSubmit={handleAssignmentSubmit}>
+            <h2>Assign trainer</h2>
+
+            <label>
+              User ID
+              <input
+                name="userId"
+                value={assignmentForm.userId}
+                onChange={handleAssignmentChange}
+                placeholder="Paste supervised user UUID"
+                required
+              />
+            </label>
+
+            <label>
+              Trainer ID
+              <input
+                name="trainerId"
+                value={assignmentForm.trainerId}
+                onChange={handleAssignmentChange}
+                placeholder="Paste trainer UUID"
+                required
+              />
+            </label>
+
+            <button type="submit">Assign trainer</button>
+
+            {assignmentMessage && <p className="message">{assignmentMessage}</p>}
           </form>
         </div>
       </section>

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/out/TrainerRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/trainer/port/out/TrainerRepository.java
@@ -1,8 +1,13 @@
 package com.anaruth.hypertrophyartapp.application.trainer.port.out;
 
 import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+
+import java.util.Optional;
 
 public interface TrainerRepository {
 
     Trainer save(Trainer trainer);
+
+    Optional<Trainer> findById(TrainerId trainerId);
 }

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserCommand.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserCommand.java
@@ -1,0 +1,9 @@
+package com.anaruth.hypertrophyartapp.application.user.port.in;
+
+import java.util.UUID;
+
+public record AssignTrainerToUserCommand(
+        UUID userId,
+        UUID trainerId
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserResult.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserResult.java
@@ -1,0 +1,13 @@
+package com.anaruth.hypertrophyartapp.application.user.port.in;
+
+import com.anaruth.hypertrophyartapp.domain.user.model.UserMode;
+
+import java.util.UUID;
+
+public record AssignTrainerToUserResult(
+        UUID userId,
+        String userName,
+        UserMode mode,
+        UUID trainerId
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserUseCase.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/in/AssignTrainerToUserUseCase.java
@@ -1,0 +1,6 @@
+package com.anaruth.hypertrophyartapp.application.user.port.in;
+
+public interface AssignTrainerToUserUseCase {
+
+    AssignTrainerToUserResult assignTrainer(AssignTrainerToUserCommand command);
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/out/UserRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/user/port/out/UserRepository.java
@@ -1,8 +1,13 @@
 package com.anaruth.hypertrophyartapp.application.user.port.out;
 
 import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+
+import java.util.Optional;
 
 public interface UserRepository {
 
     User save(User user);
+
+    Optional<User> findById(UserId userId);
 }

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/user/service/AssignTrainerToUserService.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/user/service/AssignTrainerToUserService.java
@@ -1,0 +1,49 @@
+package com.anaruth.hypertrophyartapp.application.user.service;
+
+import com.anaruth.hypertrophyartapp.application.trainer.port.out.TrainerRepository;
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserCommand;
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserResult;
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserUseCase;
+import com.anaruth.hypertrophyartapp.application.user.port.out.UserRepository;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AssignTrainerToUserService implements AssignTrainerToUserUseCase {
+
+    private final UserRepository userRepository;
+    private final TrainerRepository trainerRepository;
+
+    public AssignTrainerToUserService(
+            UserRepository userRepository,
+            TrainerRepository trainerRepository
+    ) {
+        this.userRepository = userRepository;
+        this.trainerRepository = trainerRepository;
+    }
+
+    @Override
+    public AssignTrainerToUserResult assignTrainer(AssignTrainerToUserCommand command) {
+        UserId userId = UserId.from(command.userId());
+        TrainerId trainerId = TrainerId.from(command.trainerId());
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Trainer trainer = trainerRepository.findById(trainerId)
+                .orElseThrow(() -> new IllegalArgumentException("Trainer not found"));
+
+        user.assignTrainer(trainer.id());
+        User savedUser = userRepository.save(user);
+
+        return new AssignTrainerToUserResult(
+                savedUser.id().value(),
+                savedUser.name(),
+                savedUser.mode(),
+                savedUser.trainerId().value()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
@@ -12,7 +12,11 @@ public final class TrainerId {
     }
 
     public static TrainerId newId() {
-        return new TrainerId(UUID.randomUUID());
+         return new TrainerId(UUID.randomUUID());
+    }
+
+    public static TrainerId from(UUID value) {
+        return new TrainerId(value);
     }
 
     public UUID value() {

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/User.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/User.java
@@ -1,5 +1,7 @@
 package com.anaruth.hypertrophyartapp.domain.user.model;
 
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+
 import java.util.Objects;
 
 public class User {
@@ -8,6 +10,7 @@ public class User {
     private final String name;
     private final String email;
     private final UserMode mode;
+    private TrainerId trainerId;
 
     private User(UserId id, String name, String email, UserMode mode) {
         this.id = Objects.requireNonNull(id, "User id cannot be null");
@@ -36,6 +39,16 @@ public class User {
         return mode;
     }
 
+    public TrainerId trainerId() {
+        return trainerId;
+    }
+
+    public void assignTrainer(TrainerId trainerId) {
+        if (this.mode != UserMode.SUPERVISED) {
+            throw new IllegalStateException("Only supervised users can have a trainer");
+        }
+        this.trainerId = trainerId;
+    }
     private String validateName(String name) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("User name cannot be blank");

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/user/AssignTrainerResponse.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/user/AssignTrainerResponse.java
@@ -1,0 +1,13 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.user;
+
+import com.anaruth.hypertrophyartapp.domain.user.model.UserMode;
+
+import java.util.UUID;
+
+public record AssignTrainerResponse(
+        UUID userId,
+        String userName,
+        UserMode mode,
+        UUID trainerId
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/user/UserController.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/user/UserController.java
@@ -1,5 +1,8 @@
 package com.anaruth.hypertrophyartapp.infrastructure.controller.user;
 
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserCommand;
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserResult;
+import com.anaruth.hypertrophyartapp.application.user.port.in.AssignTrainerToUserUseCase;
 import com.anaruth.hypertrophyartapp.application.user.port.in.CreateUserCommand;
 import com.anaruth.hypertrophyartapp.application.user.port.in.CreateUserResult;
 import com.anaruth.hypertrophyartapp.application.user.port.in.CreateUserUseCase;
@@ -8,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/users")
@@ -15,9 +19,14 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final CreateUserUseCase createUserUseCase;
+    private final AssignTrainerToUserUseCase assignTrainerToUserUseCase;
 
-    public UserController(CreateUserUseCase createUserUseCase) {
+    public UserController(
+            CreateUserUseCase createUserUseCase,
+            AssignTrainerToUserUseCase assignTrainerToUserUseCase
+    ) {
         this.createUserUseCase = createUserUseCase;
+        this.assignTrainerToUserUseCase = assignTrainerToUserUseCase;
     }
 
     @PostMapping
@@ -37,6 +46,24 @@ public class UserController {
                 result.name(),
                 result.email(),
                 result.mode()
+        );
+    }
+
+    @PostMapping("/{userId}/assign-trainer/{trainerId}")
+    @Operation(summary = "Assign trainer to supervised user")
+    public AssignTrainerResponse assignTrainerToUser(
+            @PathVariable UUID userId,
+            @PathVariable UUID trainerId
+    ) {
+        AssignTrainerToUserResult result = assignTrainerToUserUseCase.assignTrainer(
+                new AssignTrainerToUserCommand(userId, trainerId)
+        );
+
+        return new AssignTrainerResponse(
+                result.userId(),
+                result.userName(),
+                result.mode(),
+                result.trainerId()
         );
     }
 }

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryTrainerRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryTrainerRepository.java
@@ -2,9 +2,11 @@ package com.anaruth.hypertrophyartapp.infrastructure.persistence.memory;
 
 import com.anaruth.hypertrophyartapp.application.trainer.port.out.TrainerRepository;
 import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,5 +19,10 @@ public class InMemoryTrainerRepository implements TrainerRepository {
     public Trainer save(Trainer trainer) {
         trainers.put(trainer.id().value(), trainer);
         return trainer;
+    }
+
+    @Override
+    public Optional<Trainer> findById(TrainerId trainerId) {
+        return Optional.ofNullable(trainers.get(trainerId.value()));
     }
 }

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryUserRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/memory/InMemoryUserRepository.java
@@ -2,9 +2,11 @@ package com.anaruth.hypertrophyartapp.infrastructure.persistence.memory;
 
 import com.anaruth.hypertrophyartapp.application.user.port.out.UserRepository;
 import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,5 +19,10 @@ public class InMemoryUserRepository implements UserRepository {
     public User save(User user) {
         users.put(user.id().value(), user);
         return user;
+    }
+
+    @Override
+    public Optional<User> findById(UserId userId) {
+        return Optional.ofNullable(users.get(userId.value()));
     }
 }


### PR DESCRIPTION
## Summary

End-to-end implementation for assigning a trainer to a supervised user.

## Changes

- Added trainer assignment to User domain
- Added repository search by ID
- Added assign trainer use case
- Added POST /api/users/{userId}/assign-trainer/{trainerId}
- Added frontend form for trainer assignment

## Checks

- [x] Maven compile
- [x] Backend starts
- [x] Swagger tested
- [x] Frontend tested manually