### PR TITLE
Feature/postgres user trainer persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: hypertrophy-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: hypertrophy_art
+      POSTGRES_USER: hypertrophy_user
+      POSTGRES_PASSWORD: hypertrophy_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - hypertrophy_postgres_data:/var/lib/postgresql/data
+
+volumes:
+  hypertrophy_postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,15 @@ services:
     volumes:
       - hypertrophy_postgres_data:/var/lib/postgresql/data
 
+  mongo:
+      image: mongo:7
+      container_name: hypertrophy-mongo
+      restart: unless-stopped
+      ports:
+        - "27018:27017"
+      volumes:
+        - hypertrophy_mongo_data:/data/db
+
 volumes:
   hypertrophy_postgres_data:
+  hypertrophy_mongo_data:

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- MongoDB persistence -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
         <!-- Swagger / OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,18 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- PostgreSQL persistence -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Swagger / OpenAPI -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/Trainer.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/Trainer.java
@@ -18,6 +18,10 @@ public class Trainer {
         return new Trainer(TrainerId.newId(), name, email);
     }
 
+    public static Trainer restore(TrainerId id, String name, String email) {
+        return new Trainer(id, name, email);
+    }
+
     public TrainerId id() {
         return id;
     }

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/trainer/model/TrainerId.java
@@ -12,7 +12,7 @@ public final class TrainerId {
     }
 
     public static TrainerId newId() {
-         return new TrainerId(UUID.randomUUID());
+        return new TrainerId(UUID.randomUUID());
     }
 
     public static TrainerId from(UUID value) {

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/training/model/Training.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/training/model/Training.java
@@ -52,13 +52,53 @@ public class Training {
         );
     }
 
-    public TrainingId id() { return id; }
-    public UserId userId() { return userId; }
-    public LocalDate date() { return date; }
-    public String muscleGroup() { return muscleGroup; }
-    public String exercises() { return exercises; }
-    public TrainingIntensity intensity() { return intensity; }
-    public int durationMinutes() { return durationMinutes; }
+    public static Training restore(
+            TrainingId id,
+            UserId userId,
+            LocalDate date,
+            String muscleGroup,
+            String exercises,
+            TrainingIntensity intensity,
+            int durationMinutes
+    ) {
+        return new Training(
+                id,
+                userId,
+                date,
+                muscleGroup,
+                exercises,
+                intensity,
+                durationMinutes
+        );
+    }
+
+    public TrainingId id() {
+        return id;
+    }
+
+    public UserId userId() {
+        return userId;
+    }
+
+    public LocalDate date() {
+        return date;
+    }
+
+    public String muscleGroup() {
+        return muscleGroup;
+    }
+
+    public String exercises() {
+        return exercises;
+    }
+
+    public TrainingIntensity intensity() {
+        return intensity;
+    }
+
+    public int durationMinutes() {
+        return durationMinutes;
+    }
 
     private String validateText(String value, String field) {
         if (value == null || value.isBlank()) {

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/training/model/TrainingId.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/training/model/TrainingId.java
@@ -15,6 +15,10 @@ public final class TrainingId {
         return new TrainingId(UUID.randomUUID());
     }
 
+    public static TrainingId from(UUID value) {
+        return new TrainingId(value);
+    }
+
     public UUID value() {
         return value;
     }

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/User.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/User.java
@@ -23,6 +23,12 @@ public class User {
         return new User(UserId.newId(), name, email, mode);
     }
 
+    public static User restore(UserId id, String name, String email, UserMode mode, TrainerId trainerId) {
+        User user = new User(id, name, email, mode);
+        user.trainerId = trainerId;
+        return user;
+    }
+
     public UserId id() {
         return id;
     }

--- a/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/UserId.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/domain/user/model/UserId.java
@@ -8,7 +8,7 @@ public final class UserId {
     private final UUID value;
 
     private UserId(UUID value) {
-        this.value = Objects.requireNonNull(value, "User id cannot be null");
+                this.value = Objects.requireNonNull(value, "User id cannot be null");
     }
 
     public static UserId newId() {

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/MongoTrainingPersistenceAdapter.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/MongoTrainingPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.mongo.training;
+
+import com.anaruth.hypertrophyartapp.application.training.port.out.TrainingRepository;
+import com.anaruth.hypertrophyartapp.domain.training.model.Training;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Primary
+public class MongoTrainingPersistenceAdapter implements TrainingRepository {
+
+    private final SpringDataTrainingMongoRepository repository;
+    private final TrainingMongoMapper mapper = new TrainingMongoMapper();
+
+    public MongoTrainingPersistenceAdapter(SpringDataTrainingMongoRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Training save(Training training) {
+        TrainingDocument document = mapper.toDocument(training);
+        TrainingDocument saved = repository.save(document);
+        return mapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/SpringDataTrainingMongoRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/SpringDataTrainingMongoRepository.java
@@ -1,0 +1,7 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.mongo.training;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SpringDataTrainingMongoRepository
+        extends MongoRepository<TrainingDocument, String> {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/TrainingDocument.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/TrainingDocument.java
@@ -1,0 +1,70 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.mongo.training;
+
+import com.anaruth.hypertrophyartapp.domain.training.model.TrainingIntensity;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+
+@Document(collection = "trainings")
+public class TrainingDocument {
+
+    @Id
+    private String id;
+
+    private String userId;
+    private LocalDate date;
+    private String muscleGroup;
+    private String exercises;
+    private TrainingIntensity intensity;
+    private int durationMinutes;
+
+    public TrainingDocument() {
+    }
+
+    public TrainingDocument(
+            String id,
+            String userId,
+            LocalDate date,
+            String muscleGroup,
+            String exercises,
+            TrainingIntensity intensity,
+            int durationMinutes
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.date = date;
+        this.muscleGroup = muscleGroup;
+        this.exercises = exercises;
+        this.intensity = intensity;
+        this.durationMinutes = durationMinutes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getMuscleGroup() {
+        return muscleGroup;
+    }
+
+    public String getExercises() {
+        return exercises;
+    }
+
+    public TrainingIntensity getIntensity() {
+        return intensity;
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/TrainingMongoMapper.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/mongo/training/TrainingMongoMapper.java
@@ -1,0 +1,34 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.mongo.training;
+
+import com.anaruth.hypertrophyartapp.domain.training.model.Training;
+import com.anaruth.hypertrophyartapp.domain.training.model.TrainingId;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+
+import java.util.UUID;
+
+public class TrainingMongoMapper {
+
+    public TrainingDocument toDocument(Training training) {
+        return new TrainingDocument(
+                training.id().value().toString(),
+                training.userId().value().toString(),
+                training.date(),
+                training.muscleGroup(),
+                training.exercises(),
+                training.intensity(),
+                training.durationMinutes()
+        );
+    }
+
+    public Training toDomain(TrainingDocument document) {
+        return Training.restore(
+                TrainingId.from(UUID.fromString(document.getId())),
+                UserId.from(UUID.fromString(document.getUserId())),
+                document.getDate(),
+                document.getMuscleGroup(),
+                document.getExercises(),
+                document.getIntensity(),
+                document.getDurationMinutes()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/PostgresTrainerPersistenceAdapter.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/PostgresTrainerPersistenceAdapter.java
@@ -1,0 +1,34 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer;
+
+import com.anaruth.hypertrophyartapp.application.trainer.port.out.TrainerRepository;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@Primary
+public class PostgresTrainerPersistenceAdapter implements TrainerRepository {
+
+    private final SpringDataTrainerJpaRepository repository;
+    private final TrainerJpaMapper mapper = new TrainerJpaMapper();
+
+    public PostgresTrainerPersistenceAdapter(SpringDataTrainerJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Trainer save(Trainer trainer) {
+        TrainerEntity entity = mapper.toEntity(trainer);
+        TrainerEntity saved = repository.save(entity);
+        return mapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Trainer> findById(TrainerId id) {
+        return repository.findById(id.value().toString())
+                .map(mapper::toDomain);
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/SpringDataTrainerJpaRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/SpringDataTrainerJpaRepository.java
@@ -1,0 +1,7 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataTrainerJpaRepository
+        extends JpaRepository<TrainerEntity, String> {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/TrainerEntity.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/TrainerEntity.java
@@ -1,0 +1,36 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "trainers")
+public class TrainerEntity {
+
+    @Id
+    private String id;
+
+    private String name;
+    private String email;
+
+    public TrainerEntity() {}
+
+    public TrainerEntity(String id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/TrainerJpaMapper.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/trainer/TrainerJpaMapper.java
@@ -1,0 +1,25 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer;
+
+import com.anaruth.hypertrophyartapp.domain.trainer.model.Trainer;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+
+import java.util.UUID;
+
+public class TrainerJpaMapper {
+
+    public TrainerEntity toEntity(Trainer trainer) {
+        return new TrainerEntity(
+                trainer.id().value().toString(),
+                trainer.name(),
+                trainer.email()
+        );
+    }
+
+    public Trainer toDomain(TrainerEntity entity) {
+        return Trainer.restore(
+                TrainerId.from(UUID.fromString(entity.getId())),
+                entity.getName(),
+                entity.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/PostgresUserPersistenceAdapter.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/PostgresUserPersistenceAdapter.java
@@ -1,0 +1,34 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
+
+import com.anaruth.hypertrophyartapp.application.user.port.out.UserRepository;
+import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@Primary
+public class PostgresUserPersistenceAdapter implements UserRepository {
+
+    private final SpringDataUserJpaRepository springDataUserJpaRepository;
+    private final UserJpaMapper userJpaMapper = new UserJpaMapper();
+
+    public PostgresUserPersistenceAdapter(SpringDataUserJpaRepository springDataUserJpaRepository) {
+        this.springDataUserJpaRepository = springDataUserJpaRepository;
+    }
+
+    @Override
+    public User save(User user) {
+        UserEntity entity = userJpaMapper.toEntity(user);
+        UserEntity savedEntity = springDataUserJpaRepository.save(entity);
+        return userJpaMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<User> findById(UserId userId) {
+        return springDataUserJpaRepository.findById(userId.value().toString())
+                .map(userJpaMapper::toDomain);
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/SpringDataUserJpaRepository.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/SpringDataUserJpaRepository.java
@@ -1,0 +1,6 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserJpaRepository extends JpaRepository<UserEntity, String> {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserEntity.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserEntity.java
@@ -1,5 +1,6 @@
 package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
 
+import com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer.TrainerEntity;
 import jakarta.persistence.*;
 
 @Entity
@@ -16,21 +17,44 @@ public class UserEntity {
     @Enumerated(EnumType.STRING)
     private UserModeEntity mode;
 
-    private String trainerId;
+    @ManyToOne
+    @JoinColumn(name = "trainer_id")
+    private TrainerEntity trainer;
 
-    protected UserEntity() {}
+    protected UserEntity() {
+    }
 
-    public UserEntity(String id, String name, String email, UserModeEntity mode, String trainerId) {
+    public UserEntity(
+            String id,
+            String name,
+            String email,
+            UserModeEntity mode,
+            TrainerEntity trainer
+    ) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.mode = mode;
-        this.trainerId = trainerId;
+        this.trainer = trainer;
     }
 
-    public String getId() { return id; }
-    public String getName() { return name; }
-    public String getEmail() { return email; }
-    public UserModeEntity getMode() { return mode; }
-    public String getTrainerId() { return trainerId; }
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public UserModeEntity getMode() {
+        return mode;
+    }
+
+    public TrainerEntity getTrainer() {
+        return trainer;
+    }
 }

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserEntity.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserEntity.java
@@ -1,0 +1,36 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private UserModeEntity mode;
+
+    private String trainerId;
+
+    protected UserEntity() {}
+
+    public UserEntity(String id, String name, String email, UserModeEntity mode, String trainerId) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.mode = mode;
+        this.trainerId = trainerId;
+    }
+
+    public String getId() { return id; }
+    public String getName() { return name; }
+    public String getEmail() { return email; }
+    public UserModeEntity getMode() { return mode; }
+    public String getTrainerId() { return trainerId; }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserJpaMapper.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserJpaMapper.java
@@ -4,25 +4,36 @@ import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
 import com.anaruth.hypertrophyartapp.domain.user.model.User;
 import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
 import com.anaruth.hypertrophyartapp.domain.user.model.UserMode;
+import com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.trainer.TrainerEntity;
 
 import java.util.UUID;
 
 public class UserJpaMapper {
 
     public UserEntity toEntity(User user) {
+        TrainerEntity trainerEntity = null;
+
+        if (user.trainerId() != null) {
+            trainerEntity = new TrainerEntity(
+                    user.trainerId().value().toString(),
+                    null,
+                    null
+            );
+        }
+
         return new UserEntity(
                 user.id().value().toString(),
                 user.name(),
                 user.email(),
                 UserModeEntity.valueOf(user.mode().name()),
-                user.trainerId() == null ? null : user.trainerId().value().toString()
+                trainerEntity
         );
     }
 
     public User toDomain(UserEntity entity) {
-        TrainerId trainerId = entity.getTrainerId() == null
+        TrainerId trainerId = entity.getTrainer() == null
                 ? null
-                : TrainerId.from(UUID.fromString(entity.getTrainerId()));
+                : TrainerId.from(UUID.fromString(entity.getTrainer().getId()));
 
         return User.restore(
                 UserId.from(UUID.fromString(entity.getId())),

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserJpaMapper.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserJpaMapper.java
@@ -1,0 +1,35 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
+
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserMode;
+
+import java.util.UUID;
+
+public class UserJpaMapper {
+
+    public UserEntity toEntity(User user) {
+        return new UserEntity(
+                user.id().value().toString(),
+                user.name(),
+                user.email(),
+                UserModeEntity.valueOf(user.mode().name()),
+                user.trainerId() == null ? null : user.trainerId().value().toString()
+        );
+    }
+
+    public User toDomain(UserEntity entity) {
+        TrainerId trainerId = entity.getTrainerId() == null
+                ? null
+                : TrainerId.from(UUID.fromString(entity.getTrainerId()));
+
+        return User.restore(
+                UserId.from(UUID.fromString(entity.getId())),
+                entity.getName(),
+                entity.getEmail(),
+                UserMode.valueOf(entity.getMode().name()),
+                trainerId
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserModeEntity.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/persistence/postgres/user/UserModeEntity.java
@@ -1,0 +1,6 @@
+package com.anaruth.hypertrophyartapp.infrastructure.persistence.postgres.user;
+
+public enum UserModeEntity {
+    SELF_MANAGED,
+    SUPERVISED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
-spring.application.name=hypertrophy-art-app
+spring.application.name=hypertrophy-art
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/hypertrophy_art
+spring.datasource.username=hypertrophy_user
+spring.datasource.password=hypertrophy_pass
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,9 +6,12 @@ spring.datasource.username=hypertrophy_user
 spring.datasource.password=hypertrophy_pass
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
 
 # MongoDB
 spring.data.mongodb.uri=mongodb://localhost:27018/hypertrophy_art_mongo

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=hypertrophy-art
 
+# PostgreSQL
 spring.datasource.url=jdbc:postgresql://localhost:5432/hypertrophy_art
 spring.datasource.username=hypertrophy_user
 spring.datasource.password=hypertrophy_pass
@@ -9,4 +10,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
+# MongoDB
+spring.data.mongodb.uri=mongodb://localhost:27018/hypertrophy_art_mongo
+
+# Swagger
 springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary

Migrates persistence from in-memory repositories to real databases.

## PostgreSQL

- Added PostgreSQL Docker service
- Added JPA configuration
- Persisted users with JPA adapter
- Persisted trainers with JPA adapter
- Mapped user-trainer relationship with JPA

## MongoDB

- Added MongoDB Docker service
- Added MongoDB configuration
- Persisted training records with MongoDB adapter

## Architecture

- Domain remains free of JPA and Mongo annotations
- Application ports remain unchanged
- Controllers do not access Spring repositories directly
- Infrastructure contains database adapters

## Checks

- [x] Backend starts
- [x] Swagger works
- [x] POST /api/users works
- [x] POST /api/trainers works
- [x] POST /api/users/{userId}/assign-trainer/{trainerId} works
- [x] POST /api/trainings works