### PR TITLE
feat(progress): allow trainers to view assigned user progress

### DIFF
--- a/frontend/src/components/forms/TrainerProgressSummary.jsx
+++ b/frontend/src/components/forms/TrainerProgressSummary.jsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { API_BASE_URL } from "../../services/api";
+
+function TrainerProgressSummary() {
+  const [form, setForm] = useState({
+    trainerId: "",
+    userId: "",
+  });
+
+  const [summary, setSummary] = useState(null);
+  const [message, setMessage] = useState("");
+
+  function handleChange(event) {
+    const { name, value } = event.target;
+    setForm({ ...form, [name]: value });
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/api/progress-summary/trainers/${form.trainerId}/users/${form.userId}`
+      );
+
+      if (!response.ok) {
+        throw new Error("Could not load assigned user progress");
+      }
+
+      const data = await response.json();
+
+      setSummary(data);
+      setMessage("");
+    } catch (error) {
+      setSummary(null);
+      setMessage("Error loading assigned user progress");
+    }
+  }
+
+  return (
+    <section className="form-card">
+      <h2>Trainer progress view</h2>
+
+      <form onSubmit={handleSubmit} className="summary-search">
+        <input
+          name="trainerId"
+          placeholder="Trainer ID"
+          value={form.trainerId}
+          onChange={handleChange}
+          required
+        />
+
+        <input
+          name="userId"
+          placeholder="Assigned User ID"
+          value={form.userId}
+          onChange={handleChange}
+          required
+        />
+
+        <button type="submit">View assigned user progress</button>
+      </form>
+
+      {message && <p className="message">{message}</p>}
+
+      {summary && (
+        <div className="summary-list">
+          <p><span>User ID</span><strong>{summary.userId}</strong></p>
+          <p><span>Total trainings</span><strong>{summary.totalTrainings}</strong></p>
+          <p><span>Latest training</span><strong>{summary.latestTrainingMuscleGroup ?? "No data"} — {summary.latestTrainingDate ?? ""}</strong></p>
+          <p><span>Recovery fatigue</span><strong>{summary.latestRecoveryFatigue ?? "No data"}</strong></p>
+          <p><span>Sleep hours</span><strong>{summary.latestRecoverySleepHours}</strong></p>
+          <p><span>Calories</span><strong>{summary.latestNutritionCalories ?? "No data"}</strong></p>
+          <p><span>Protein</span><strong>{summary.latestNutritionProteinGrams ?? "No data"}</strong></p>
+          <p><span>Stress</span><strong>{summary.latestWellnessStress ?? "No data"}</strong></p>
+          <p><span>Motivation</span><strong>{summary.latestWellnessMotivation ?? "No data"}</strong></p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default TrainerProgressSummary;

--- a/frontend/src/components/layout/Dashboard.jsx
+++ b/frontend/src/components/layout/Dashboard.jsx
@@ -10,6 +10,7 @@ import RecoveryForm from "../forms/RecoveryForm";
 import NutritionForm from "../forms/NutritionForm";
 import WellnessForm from "../forms/WellnessForm";
 import ProgressSummary from "../forms/ProgressSummary";
+import TrainerProgressSummary from "../forms/TrainerProgressSummary";
 function Dashboard() {
 
   const [activeTab, setActiveTab] = useState("users");
@@ -50,6 +51,8 @@ function Dashboard() {
         {activeTab === "wellness" && <WellnessForm />}
 
         {activeTab === "progress" && <ProgressSummary />}
+
+        {activeTab === "trainer-progress" && <TrainerProgressSummary />}
 
       </section>
 

--- a/frontend/src/components/layout/NavigationTabs.jsx
+++ b/frontend/src/components/layout/NavigationTabs.jsx
@@ -8,7 +8,8 @@ function NavigationTabs({ activeTab, onTabChange }) {
     "recovery",
     "nutrition",
     "wellness",
-    "progress"
+    "progress",
+    "trainer-progress"
   ];
 
   return (

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/progress/port/in/ViewAssignedUserProgressUseCase.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/progress/port/in/ViewAssignedUserProgressUseCase.java
@@ -1,0 +1,8 @@
+package com.anaruth.hypertrophyartapp.application.progress.port.in;
+
+import java.util.UUID;
+
+public interface ViewAssignedUserProgressUseCase {
+
+    ProgressSummaryResult viewAssignedUserProgress(UUID trainerId, UUID userId);
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/progress/service/ViewAssignedUserProgressService.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/progress/service/ViewAssignedUserProgressService.java
@@ -1,0 +1,45 @@
+package com.anaruth.hypertrophyartapp.application.progress.service;
+
+import com.anaruth.hypertrophyartapp.application.progress.port.in.ProgressSummaryResult;
+import com.anaruth.hypertrophyartapp.application.progress.port.in.ViewAssignedUserProgressUseCase;
+import com.anaruth.hypertrophyartapp.application.progress.port.in.ViewProgressSummaryUseCase;
+import com.anaruth.hypertrophyartapp.application.user.port.out.UserRepository;
+import com.anaruth.hypertrophyartapp.domain.trainer.model.TrainerId;
+import com.anaruth.hypertrophyartapp.domain.user.model.User;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ViewAssignedUserProgressService implements ViewAssignedUserProgressUseCase {
+
+    private final UserRepository userRepository;
+    private final ViewProgressSummaryUseCase viewProgressSummaryUseCase;
+
+    public ViewAssignedUserProgressService(
+            UserRepository userRepository,
+            ViewProgressSummaryUseCase viewProgressSummaryUseCase
+    ) {
+        this.userRepository = userRepository;
+        this.viewProgressSummaryUseCase = viewProgressSummaryUseCase;
+    }
+
+    @Override
+    public ProgressSummaryResult viewAssignedUserProgress(UUID trainerUuid, UUID userUuid) {
+        User user = userRepository.findById(UserId.from(userUuid))
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        TrainerId assignedTrainerId = user.trainerId();
+
+        if (assignedTrainerId == null) {
+            throw new IllegalStateException("User is not assigned to a trainer");
+        }
+
+        if (!assignedTrainerId.value().equals(trainerUuid)) {
+            throw new IllegalStateException("Trainer is not assigned to this user");
+        }
+
+        return viewProgressSummaryUseCase.viewByUserId(userUuid);
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/progress/ProgressSummaryController.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/progress/ProgressSummaryController.java
@@ -1,6 +1,7 @@
 package com.anaruth.hypertrophyartapp.infrastructure.controller.progress;
 
 import com.anaruth.hypertrophyartapp.application.progress.port.in.ProgressSummaryResult;
+import com.anaruth.hypertrophyartapp.application.progress.port.in.ViewAssignedUserProgressUseCase;
 import com.anaruth.hypertrophyartapp.application.progress.port.in.ViewProgressSummaryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,15 +15,43 @@ import java.util.UUID;
 public class ProgressSummaryController {
 
     private final ViewProgressSummaryUseCase viewProgressSummaryUseCase;
+    private final ViewAssignedUserProgressUseCase viewAssignedUserProgressUseCase;
 
-    public ProgressSummaryController(ViewProgressSummaryUseCase viewProgressSummaryUseCase) {
+    public ProgressSummaryController(
+            ViewProgressSummaryUseCase viewProgressSummaryUseCase,
+            ViewAssignedUserProgressUseCase viewAssignedUserProgressUseCase
+    ) {
         this.viewProgressSummaryUseCase = viewProgressSummaryUseCase;
+        this.viewAssignedUserProgressUseCase = viewAssignedUserProgressUseCase;
     }
 
     @GetMapping("/{userId}")
     @Operation(summary = "View progress summary by user id")
     public ProgressSummaryResponse viewByUserId(@PathVariable UUID userId) {
         ProgressSummaryResult result = viewProgressSummaryUseCase.viewByUserId(userId);
+
+        return new ProgressSummaryResponse(
+                result.userId(),
+                result.totalTrainings(),
+                result.latestTrainingDate(),
+                result.latestTrainingMuscleGroup(),
+                result.latestRecoveryFatigue(),
+                result.latestRecoverySleepHours(),
+                result.latestNutritionCalories(),
+                result.latestNutritionProteinGrams(),
+                result.latestWellnessStress(),
+                result.latestWellnessMotivation()
+        );
+    }
+
+    @GetMapping("/trainers/{trainerId}/users/{userId}")
+    @Operation(summary = "Trainer views assigned user progress summary")
+    public ProgressSummaryResponse viewAssignedUserProgress(
+            @PathVariable UUID trainerId,
+            @PathVariable UUID userId
+    ) {
+        ProgressSummaryResult result = viewAssignedUserProgressUseCase
+                .viewAssignedUserProgress(trainerId, userId);
 
         return new ProgressSummaryResponse(
                 result.userId(),


### PR DESCRIPTION
## Summary
- Added trainer-specific progress summary endpoint
- Validates that the user is assigned to the trainer
- Added Trainer-Progress tab in the dashboard
- Reused progress summary UI style

## Checks
- [x] Swagger endpoint works
- [x] Frontend trainer progress view connects
- [x] Existing progress summary still works