### PR TITLE
feat(recommendation): add deload and fatigue recommendations

### DIFF
--- a/frontend/src/components/forms/DeloadRecommendation.jsx
+++ b/frontend/src/components/forms/DeloadRecommendation.jsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { API_BASE_URL } from "../../services/api";
+
+function DeloadRecommendation() {
+  const [userId, setUserId] = useState("");
+  const [recommendation, setRecommendation] = useState(null);
+  const [message, setMessage] = useState("");
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/api/recommendations/deload/${userId}`
+      );
+
+      if (!response.ok) {
+        throw new Error("Could not load recommendation");
+      }
+
+      const data = await response.json();
+
+      setRecommendation(data);
+      setMessage("");
+    } catch (error) {
+      setRecommendation(null);
+      setMessage("Error loading recommendation");
+    }
+  }
+
+  return (
+    <section className="form-card">
+      <h2>Deload recommendation</h2>
+
+      <form onSubmit={handleSubmit} className="summary-search">
+        <input
+          name="userId"
+          placeholder="User ID"
+          value={userId}
+          onChange={(event) => setUserId(event.target.value)}
+          required
+        />
+
+        <button type="submit">View recommendation</button>
+      </form>
+
+      {message && <p className="message">{message}</p>}
+
+      {recommendation && (
+        <div className="summary-list">
+          <p>
+            <span>User ID</span>
+            <strong>{recommendation.userId}</strong>
+          </p>
+
+          <p>
+            <span>Recommendation</span>
+            <strong>{recommendation.recommendation}</strong>
+          </p>
+
+          <p>
+            <span>Reason</span>
+            <strong>{recommendation.reason}</strong>
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default DeloadRecommendation;

--- a/frontend/src/components/layout/Dashboard.jsx
+++ b/frontend/src/components/layout/Dashboard.jsx
@@ -11,6 +11,7 @@ import NutritionForm from "../forms/NutritionForm";
 import WellnessForm from "../forms/WellnessForm";
 import ProgressSummary from "../forms/ProgressSummary";
 import TrainerProgressSummary from "../forms/TrainerProgressSummary";
+import DeloadRecommendation from "../forms/DeloadRecommendation";
 function Dashboard() {
 
   const [activeTab, setActiveTab] = useState("users");
@@ -53,6 +54,8 @@ function Dashboard() {
         {activeTab === "progress" && <ProgressSummary />}
 
         {activeTab === "trainer-progress" && <TrainerProgressSummary />}
+
+        {activeTab === "recommendation" && <DeloadRecommendation />}
 
       </section>
 

--- a/frontend/src/components/layout/NavigationTabs.jsx
+++ b/frontend/src/components/layout/NavigationTabs.jsx
@@ -9,7 +9,8 @@ function NavigationTabs({ activeTab, onTabChange }) {
     "nutrition",
     "wellness",
     "progress",
-    "trainer-progress"
+    "trainer-progress",
+    "recommendation"
   ];
 
   return (

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/port/in/DeloadRecommendationResult.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/port/in/DeloadRecommendationResult.java
@@ -1,0 +1,10 @@
+package com.anaruth.hypertrophyartapp.application.recommendation.port.in;
+
+import java.util.UUID;
+
+public record DeloadRecommendationResult(
+        UUID userId,
+        String recommendation,
+        String reason
+) {
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/port/in/ViewDeloadRecommendationUseCase.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/port/in/ViewDeloadRecommendationUseCase.java
@@ -1,0 +1,8 @@
+package com.anaruth.hypertrophyartapp.application.recommendation.port.in;
+
+import java.util.UUID;
+
+public interface ViewDeloadRecommendationUseCase {
+
+    DeloadRecommendationResult viewByUserId(UUID userId);
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/service/ViewDeloadRecommendationService.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/application/recommendation/service/ViewDeloadRecommendationService.java
@@ -1,0 +1,110 @@
+package com.anaruth.hypertrophyartapp.application.recommendation.service;
+
+import com.anaruth.hypertrophyartapp.application.recommendation.port.in.DeloadRecommendationResult;
+import com.anaruth.hypertrophyartapp.application.recommendation.port.in.ViewDeloadRecommendationUseCase;
+import com.anaruth.hypertrophyartapp.application.recovery.port.out.RecoveryCheckInRepository;
+import com.anaruth.hypertrophyartapp.application.training.port.out.TrainingRepository;
+import com.anaruth.hypertrophyartapp.application.user.port.out.UserRepository;
+import com.anaruth.hypertrophyartapp.application.wellness.port.out.WellnessCheckInRepository;
+import com.anaruth.hypertrophyartapp.domain.recovery.model.FatigueLevel;
+import com.anaruth.hypertrophyartapp.domain.recovery.model.RecoveryCheckIn;
+import com.anaruth.hypertrophyartapp.domain.training.model.Training;
+import com.anaruth.hypertrophyartapp.domain.training.model.TrainingIntensity;
+import com.anaruth.hypertrophyartapp.domain.user.model.UserId;
+import com.anaruth.hypertrophyartapp.domain.wellness.model.WellnessCheckIn;
+import com.anaruth.hypertrophyartapp.domain.wellness.model.WellnessLevel;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ViewDeloadRecommendationService implements ViewDeloadRecommendationUseCase {
+
+    private final UserRepository userRepository;
+    private final TrainingRepository trainingRepository;
+    private final RecoveryCheckInRepository recoveryCheckInRepository;
+    private final WellnessCheckInRepository wellnessCheckInRepository;
+
+    public ViewDeloadRecommendationService(
+            UserRepository userRepository,
+            TrainingRepository trainingRepository,
+            RecoveryCheckInRepository recoveryCheckInRepository,
+            WellnessCheckInRepository wellnessCheckInRepository
+    ) {
+        this.userRepository = userRepository;
+        this.trainingRepository = trainingRepository;
+        this.recoveryCheckInRepository = recoveryCheckInRepository;
+        this.wellnessCheckInRepository = wellnessCheckInRepository;
+    }
+
+    @Override
+    public DeloadRecommendationResult viewByUserId(UUID userUuid) {
+        UserId userId = UserId.from(userUuid);
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<Training> trainings = trainingRepository.findByUserId(userId);
+        List<RecoveryCheckIn> recoveries = recoveryCheckInRepository.findByUserId(userId);
+        List<WellnessCheckIn> wellnessCheckIns = wellnessCheckInRepository.findByUserId(userId);
+
+        Training latestTraining = trainings.stream()
+                .max(Comparator.comparing(Training::date))
+                .orElse(null);
+
+        RecoveryCheckIn latestRecovery = recoveries.stream()
+                .max(Comparator.comparing(RecoveryCheckIn::date))
+                .orElse(null);
+
+        WellnessCheckIn latestWellness = wellnessCheckIns.stream()
+                .max(Comparator.comparing(WellnessCheckIn::date))
+                .orElse(null);
+
+        boolean highTrainingIntensity =
+                latestTraining != null && latestTraining.intensity() == TrainingIntensity.HIGH;
+
+        boolean highFatigue =
+                latestRecovery != null && latestRecovery.fatigueLevel() == FatigueLevel.HIGH;
+
+        boolean lowSleep =
+                latestRecovery != null && latestRecovery.sleepHours() < 6;
+
+        boolean highStress =
+                latestWellness != null && latestWellness.stressLevel() == WellnessLevel.HIGH;
+
+        boolean lowMotivation =
+                latestWellness != null && latestWellness.motivationLevel() == WellnessLevel.LOW;
+
+        if (highFatigue && lowSleep) {
+            return new DeloadRecommendationResult(
+                    userUuid,
+                    "Deload recommended",
+                    "High fatigue and low sleep detected"
+            );
+        }
+
+        if (highStress && lowMotivation) {
+            return new DeloadRecommendationResult(
+                    userUuid,
+                    "Deload recommended",
+                    "High stress and low motivation detected"
+            );
+        }
+
+        if (highTrainingIntensity && (highFatigue || highStress)) {
+            return new DeloadRecommendationResult(
+                    userUuid,
+                    "Reduce training load",
+                    "High training intensity combined with fatigue or stress detected"
+            );
+        }
+
+        return new DeloadRecommendationResult(
+                userUuid,
+                "Recovery status is stable",
+                "No critical fatigue indicators detected"
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/recommendation/DeloadRecommendationController.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/recommendation/DeloadRecommendationController.java
@@ -1,0 +1,36 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.recommendation;
+
+import com.anaruth.hypertrophyartapp.application.recommendation.port.in.DeloadRecommendationResult;
+import com.anaruth.hypertrophyartapp.application.recommendation.port.in.ViewDeloadRecommendationUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/recommendations")
+@Tag(name = "Recommendations", description = "Training load and deload recommendations")
+public class DeloadRecommendationController {
+
+    private final ViewDeloadRecommendationUseCase viewDeloadRecommendationUseCase;
+
+    public DeloadRecommendationController(
+            ViewDeloadRecommendationUseCase viewDeloadRecommendationUseCase
+    ) {
+        this.viewDeloadRecommendationUseCase = viewDeloadRecommendationUseCase;
+    }
+
+    @GetMapping("/deload/{userId}")
+    @Operation(summary = "View deload recommendation by user id")
+    public DeloadRecommendationResponse viewByUserId(@PathVariable UUID userId) {
+        DeloadRecommendationResult result =
+                viewDeloadRecommendationUseCase.viewByUserId(userId);
+
+        return new DeloadRecommendationResponse(
+                result.userId(),
+                result.recommendation(),
+                result.reason()
+        );
+    }
+}

--- a/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/recommendation/DeloadRecommendationResponse.java
+++ b/src/main/java/com/anaruth/hypertrophyartapp/infrastructure/controller/recommendation/DeloadRecommendationResponse.java
@@ -1,0 +1,10 @@
+package com.anaruth.hypertrophyartapp.infrastructure.controller.recommendation;
+
+import java.util.UUID;
+
+public record DeloadRecommendationResponse(
+        UUID userId,
+        String recommendation,
+        String reason
+) {
+}


### PR DESCRIPTION
## Summary
- Added deload recommendation backend endpoint
- Reused existing Training, Recovery and Wellness data
- Added Recommendation tab in frontend dashboard
- No persistence required for recommendations

## Checks
- [x] Swagger endpoint works
- [x] Frontend recommendation view connects
- [x] Existing modules still work